### PR TITLE
Elements with negative `tabindex` can't be focused by keyboard

### DIFF
--- a/script/elements.js
+++ b/script/elements.js
@@ -45,5 +45,6 @@ export function getKeyboardFocusableElements (element = document) {
   return [...element.querySelectorAll(
     'a, button, input, textarea, select, details, [tabindex]'
   )]
-    .filter(el => !el.hasAttribute('disabled') && (!el.hasAttribute('tabindex') || el.getAttribute('tabindex') >= 0))
+    .filter(el => !el.hasAttribute('disabled'))
+    .filter(el => !el.hasAttribute('tabindex') || el.getAttribute('tabindex') >= 0)
 }

--- a/script/elements.js
+++ b/script/elements.js
@@ -43,7 +43,7 @@ export function getFocusableElements (element = document) {
  */
 export function getKeyboardFocusableElements (element = document) {
   return [...element.querySelectorAll(
-    'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])'
+    'a, button, input, textarea, select, details, [tabindex]'
   )]
-    .filter(el => !el.hasAttribute('disabled'))
+    .filter(el => !el.hasAttribute('disabled') && (!el.hasAttribute('tabindex') || el.getAttribute('tabindex') >= 0))
 }


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) (and local testing, just to be sure :P):

> A negative value (usually tabindex="-1") means that the element is not reachable via sequential keyboard navigation...

So it's not just the `[tabindex="-1"]` selector we must filter out, but any `tabindex < 0`. Plus it should be filtered from all the selectors and not only `[tabindex]`. This way you could still select `a[tabindex="-1"]` because of the `a` selector.