### PR TITLE
fix: :bug: Use computedStyleMap instead of display property on focusable.js

### DIFF
--- a/src/browser/accessibility/focusable.js
+++ b/src/browser/accessibility/focusable.js
@@ -15,7 +15,7 @@ export default function Focusable (element = document) {
         return (
           !el.hasAttribute('disabled') &&
           !el.hasAttribute('hidden') &&
-          el.style.display !== 'none'
+          el.computedStyleMap().get('display').value !== 'none'
         )
       })
     },


### PR DESCRIPTION
Now it filters also elements hidden via style tags or stylesheets, not only inline styles